### PR TITLE
Bug fix CSRF Lab

### DIFF
--- a/app/training/controllers/CSRF.php
+++ b/app/training/controllers/CSRF.php
@@ -14,7 +14,7 @@ class CSRF
     }
 
     public static function logout(){
-	setcookie('token',null,time()-3600,'/; Secure; SameSite=None');
+	setcookie('token',null,time()-3600,'/');
 	\View::redirect('/');
     }
 
@@ -165,11 +165,11 @@ class CSRF
         if( isset($_POST["username"],$_POST["password"]) ){
             $error = true;
             if( $_POST["username"] === 'admin' && $users["admin"]["password"] == $_POST["password"] ){
-		setcookie('token','9738EFC3561120092F7AB66514547475',time()+3600,'/; Secure; SameSite=None');
+		setcookie('token','9738EFC3561120092F7AB66514547475',time()+3600,'/');
 		\View::redirect('/');
             }
             if( $_POST["username"] === 'ben' && $users["ben"]["password"] == $_POST["password"] ){
-	        setcookie('token','649EFEE221D752E4E943D7811B95408E',time()+3600,'/; Secure; SameSite=None');
+	        setcookie('token','649EFEE221D752E4E943D7811B95408E',time()+3600,'/');
                 \View::redirect('/');
             }
         }


### PR DESCRIPTION
I encountered an issue with the CSRF lab while on tryhackme. I was not able to log in with either of the 2 acceptable username and password combinations: `admin/admin` or `ben/ben`. 

My login is not successful because the cookie `token` is not being set even when using correct login credentials. This is because the `SameSite=none` attribute is set, which requires the `Secure` attribute to be set. The `Secure` attribute has to be run over an encrypted connection or else it will not be set. Neither the THM machine nor local machines have an encrypted connection, so it seems safe and beneficial to remove them.